### PR TITLE
unlist function usage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: The two main functions in the package are pairwiseAlignment() and
 biocViews: Alignment, SequenceMatching, Sequencing, Genetics
 URL: https://bioconductor.org/packages/pwalign
 BugReports: https://github.com/Bioconductor/pwalign/issues
-Version: 1.3.2
+Version: 1.3.3
 License: Artistic-2.0
 Encoding: UTF-8
 Authors@R: c(

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+VERSION 1.3.3
+-------------
+
+- Bug fix `stringDist.R` and `pairwiseAlignment.R` due to `unlist` function.
+
 VERSION 1.2.0
 -------------
 

--- a/R/pairwiseAlignment.R
+++ b/R/pairwiseAlignment.R
@@ -89,7 +89,7 @@ function(pattern,
            ncol = length(availableLetters),
            dimnames = list(availableLetters, availableLetters))
   substitutionArray <-
-    array(unlist(substitutionMatrix, substitutionMatrix), dim = c(dim(substitutionMatrix), 2),
+    array(unlist(substitutionMatrix), dim = c(dim(substitutionMatrix), 2),
           dimnames = list(availableLetters, availableLetters, c("0", "1")))
   substitutionLookupTable <-
     buildLookupTable(alphabetToCodes[availableLetters],

--- a/R/stringDist.R
+++ b/R/stringDist.R
@@ -84,7 +84,7 @@ function(x,
              ncol = length(availableLetters),
              dimnames = list(availableLetters, availableLetters))
     substitutionArray <-
-      array(unlist(substitutionMatrix, substitutionMatrix),
+      array(unlist(substitutionMatrix),
             dim = c(dim(substitutionMatrix), 2),
             dimnames = list(availableLetters, availableLetters, c("0", "1")))
     substitutionLookupTable <-


### PR DESCRIPTION
Dear @hpages,
I have changed the following parts in `stringDist.R` and `pairwiseAlignment.R`:


`stringDist.R`
```
    substitutionArray <-
      array(unlist(substitutionMatrix, substitutionMatrix),
            dim = c(dim(substitutionMatrix), 2),
            dimnames = list(availableLetters, availableLetters, c("0", "1")))
```
>>>

```
    substitutionArray <-
      array(unlist(substitutionMatrix),
            dim = c(dim(substitutionMatrix), 2),
            dimnames = list(availableLetters, availableLetters, c("0", "1")))
```

`pairwiseAlignment.R`
```
  substitutionArray <-
    array(unlist(substitutionMatrix, substitutionMatrix), dim = c(dim(substitutionMatrix), 2),
          dimnames = list(availableLetters, availableLetters, c("0", "1")))
```
>>>
```
  substitutionArray <-
    array(unlist(substitutionMatrix), dim = c(dim(substitutionMatrix), 2),
          dimnames = list(availableLetters, availableLetters, c("0", "1")))
```

Now, the `unlist` related error is gone, however, if there was a reason why the `substitutionMatrix` was doubled in the original code and if `pwalign` might now show unexpected behaviour can only be verified by the original developer I guess.

Thank you in anticipation

Best regards

Kristian